### PR TITLE
now ordering repeating group members

### DIFF
--- a/features/nested_builder.feature
+++ b/features/nested_builder.feature
@@ -62,7 +62,7 @@ Then the FIX message should be:
 }
 """
 
-@wip @ignore_length_and_checksum
+@ignore_length_and_checksum
 Scenario: Building fix message with repeating group builder
 Given I create the following FIX.4.2 message of type "News":
 | PossDupFlag  | false                                        |


### PR DESCRIPTION
These changes will force the order of the fields within the repeating group to match the order specified in the test.
