### PR TITLE
travis build using jruby, not jruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm:
 - jruby-18mode
 - jruby-19mode
-- jruby-stable
+- jruby
 env:
 - JAVA_OPTS=-XX:MaxPermSize=2048m
 


### PR DESCRIPTION
on our [travis](https://travis-ci.org/) builds, we've been seeing the following cucumber error with the version `jruby-head` as part of our build matrix:

```
undefined method `grey' for Cucumber::Formatter::Console:Module (NoMethodError)
(eval):2:in `comment'
org/jruby/RubyProc.java:275:in `call'
/home/travis/build/connamara/fix_spec/vendor/bundle/jruby/2.1/gems/cucumber-1.3.8/lib/cucumber/formatter/console.rb:50:in `format_string'
...
```

When I pull down `jruby-head` on a local machine, I get the same result. I don't consider it necessary to be using the `head` jruby version, as that isn't necessarily a stable version of jruby, and therefore failures may not be indicative of a regression. Opting for `jruby` we should be able to avoid errors like these.

(crossing fingers, hoping travis likes this)
